### PR TITLE
Fix postinstall script paths

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,8 +29,7 @@
     "chownr": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.3.tgz",
-      "integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw==",
-      "dev": true
+      "integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw=="
     },
     "commander": {
       "version": "2.15.1",
@@ -69,7 +68,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.0.0.tgz",
       "integrity": "sha512-40Qz+LFXmd9tzYVnnBmZvFfvAADfUA14TXPK1s7IfElJTIZ97rA8w4Kin7Wt5JBrC3ShnnFJO/5vPjPEeJIq9A==",
-      "dev": true,
       "requires": {
         "minipass": "^3.0.0"
       }
@@ -140,14 +138,12 @@
     "minimist": {
       "version": "0.0.8",
       "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "minipass": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.1.tgz",
       "integrity": "sha512-UFqVihv6PQgwj8/yTGvl9kPz7xIAY+R5z6XYjRInD3Gk3qx6QGSD6zEcpeG4Dy/lQnv1J6zv8ejV90hyYIKf3w==",
-      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -156,7 +152,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.0.tgz",
       "integrity": "sha512-EzTZN/fjSvifSX0SlqUERCN39o6T40AMarPbv0MrarSFtIITCBh7bi+dU8nxGFHuqs9jdIAeoYoKuQAAASsPPA==",
-      "dev": true,
       "requires": {
         "minipass": "^3.0.0",
         "yallist": "^4.0.0"
@@ -166,7 +161,6 @@
       "version": "0.5.1",
       "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       }
@@ -224,7 +218,6 @@
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/tar/-/tar-5.0.5.tgz",
       "integrity": "sha512-MNIgJddrV2TkuwChwcSNds/5E9VijOiw7kAc1y5hTNJoLDSuIyid2QtLYiCYNnICebpuvjhPQZsXwUL0O3l7OQ==",
-      "dev": true,
       "requires": {
         "chownr": "^1.1.3",
         "fs-minipass": "^2.0.0",
@@ -243,8 +236,7 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,9 +27,10 @@
     "url": "https://github.com/runk/node-geolite2/issues"
   },
   "homepage": "https://github.com/runk/node-geolite2#readme",
-  "dependencies": {},
-  "devDependencies": {
-    "mocha": "^5.2.0",
+  "dependencies": {
     "tar": "^5.0.5"
+  },
+  "devDependencies": {
+    "mocha": "^5.2.0"
   }
 }

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -22,7 +22,7 @@ links.forEach(url =>
   download(url).then(result =>
     result.pipe(tar.t()).on("entry", entry => {
       if (entry.path.endsWith(".mmdb")) {
-        const dstFilename = path.join("./dbs", path.basename(entry.path));
+        const dstFilename = path.join(__dirname, "../dbs", path.basename(entry.path));
         entry.pipe(fs.createWriteStream(dstFilename));
       }
     })

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -10,6 +10,10 @@ const links = [
   "https://geolite.maxmind.com/download/geoip/database/GeoLite2-ASN.tar.gz"
 ];
 
+const downloadPath = path.join(__dirname, "../dbs");
+
+if (!fs.existsSync(downloadPath)) fs.mkdirSync(downloadPath);
+
 const download = url =>
   new Promise(resolve => {
     https.get(url, function(response) {
@@ -22,7 +26,7 @@ links.forEach(url =>
   download(url).then(result =>
     result.pipe(tar.t()).on("entry", entry => {
       if (entry.path.endsWith(".mmdb")) {
-        const dstFilename = path.join(__dirname, "../dbs", path.basename(entry.path));
+        const dstFilename = path.join(downloadPath, path.basename(entry.path));
         entry.pipe(fs.createWriteStream(dstFilename));
       }
     })


### PR DESCRIPTION
Following on the conversation in #12:

> Re absolute path - it's already there /index.js@master#L5 

The postinstall script does not use `__dirname` and instead builds a path from `./dbs`, which resolves to the whole project root's dir when installing `geolite2` as a dep:
https://github.com/runk/node-geolite2/blob/71485eff78388ba694a2f142ceeb0f013300d4e0/scripts/postinstall.js#L25
Using `path.join(__dirname, "../dbs",...` instead correctly resolves to a `dbs` subfolder in the `geolite2` install directory (supposedly somewhere inside a parent's `node_modules`).

Also, you're using a `.gitkeep` file to keep the empty `dbs` directory on GitHub but it seems that npm does not create the directory when cloning - so you need to create it first to avoid an `ENOENT` when writing the database files.

Finally, `tar` is set as a devDependency but is required by the postinstall script, which - at least on my end, running node12 - caused some problems. I moved it to regular dependencies.

---

Closes #12