### PR TITLE
Make dbs downloaded selectable using package.json property

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Maxmind's GeoLite2 Free Databases download helper.
 
 ## Configuration
 
+### Access Key
+
 **IMPORTANT** You must setup `MAXMIND_LICENSE_KEY` environment variable be able to download databases. To do so, go to the https://www.maxmind.com/en/geolite2/signup, create a free account and generate new license key.
 
 If you don't have access to the environment variables during installation, you can provide license key via `package.json`:
@@ -23,6 +25,25 @@ If you don't have access to the environment variables during installation, you c
 ```
 
 Beware of security risks of adding keys and secrets to your repository!
+
+### Selecting databases to download
+
+You can select the dbs you want downloaded by adding a `selected-dbs` property on `geolite2` via `package.json`.
+
+`selected-dbs` must be an array of strings, one or more of the values `City`, `Country`, `ASN`.
+
+If `selected-dbs` is unset, or is set but empty, all dbs will be downloaded.
+
+```jsonc
+{
+  ...
+  "geolite2": {
+    "selected-dbs": ["City", "Country", "ASN"]
+  }
+  ...
+}
+```
+
 
 ## Usage
 

--- a/index.js
+++ b/index.js
@@ -1,9 +1,15 @@
-var path = require("path");
+const path = require("path");
+
+const {selectedDbs} = require('./utils');
+const selected = selectedDbs();
+
+const makePath = (type) => path.resolve(__dirname, `dbs/GeoLite2-${type}.mmdb`);
+
+const paths = selected.reduce((a,c) => {
+  a[c.toLowerCase()] = makePath(c);
+  return a;
+}, {});
 
 module.exports = {
-  paths: {
-    city: path.resolve(__dirname, "dbs/GeoLite2-City.mmdb"),
-    country: path.resolve(__dirname, "dbs/GeoLite2-Country.mmdb"),
-    asn: path.resolve(__dirname, "dbs/GeoLite2-ASN.mmdb")
-  }
+  paths
 };

--- a/package.json
+++ b/package.json
@@ -33,5 +33,12 @@
   "devDependencies": {
     "mocha": "^5.2.0",
     "semantic-release": "^17.0.8"
+  },
+  "geolite2": {
+    "selected-dbs": [
+      "City",
+      "Country",
+      "ASN"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,12 +33,5 @@
   "devDependencies": {
     "mocha": "^5.2.0",
     "semantic-release": "^17.0.8"
-  },
-  "geolite2": {
-    "selected-dbs": [
-      "City",
-      "Country",
-      "ASN"
-    ]
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -2,22 +2,31 @@ const assert = require('assert');
 const fs = require('fs');
 const geolite2 = require('../');
 
+const {selectedDbs} = require('../utils');
+const selected = selectedDbs();
+
 describe('geolite2', function() {
-  it('should return a valid city db path', function() {
-    var stat = fs.statSync(geolite2.paths.city);
-    assert(stat.size > 1e6);
-    assert(stat.ctime);
-  });
+  if(selected.includes('City')) {
+    it('should return a valid city db path', function () {
+      var stat = fs.statSync(geolite2.paths.city);
+      assert(stat.size > 1e6);
+      assert(stat.ctime);
+    });
+  }
 
-  it('should return a valid country db path', function() {
-    var stat = fs.statSync(geolite2.paths.country);
-    assert(stat.size > 1e6);
-    assert(stat.ctime);
-  });
+  if(selected.includes('Country')) {
+    it('should return a valid country db path', function () {
+      var stat = fs.statSync(geolite2.paths.country);
+      assert(stat.size > 1e6);
+      assert(stat.ctime);
+    });
+  }
 
-  it('should return a valid ASN db path', function() {
-    var stat = fs.statSync(geolite2.paths.asn);
-    assert(stat.size > 1e6);
-    assert(stat.ctime);
-  });
+  if(selected.includes('ASN')) {
+    it('should return a valid ASN db path', function () {
+      var stat = fs.statSync(geolite2.paths.asn);
+      assert(stat.size > 1e6);
+      assert(stat.ctime);
+    });
+  }
 });

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,61 @@
+const path = require('path');
+const fs = require('fs');
+
+const cwdPath = (file) => path.join(process.env['INIT_CWD'] || process.cwd(), file);
+
+const getConfig = () => {
+    const packageJsonFilename = cwdPath('package.json');
+  const packageJson = require(packageJsonFilename);
+  return packageJson['geolite2'] || {};
+};
+
+const getLicense = () => {
+  const envKey = process.env.MAXMIND_LICENSE_KEY;
+  if(envKey) return envKey;
+  
+  const config = getConfig();
+  const licenseKey = config['license-key'];
+  if(licenseKey) return licenseKey;
+
+  const configFile = config['license-file'];
+  if(!configFile) return;
+
+  const configFilePath = cwdPath(configFile);
+  return fs.existsSync(configFilePath) 
+       ? fs.readFileSync(configFilePath, 'utf8').trim()
+       : undefined;
+}
+
+const selectedDbs = () => {
+  const config = getConfig();
+  const selected = config['selected-dbs'];
+  const valids = ['City', 'Country', 'ASN'];
+  if(!selected) return valids;
+  if(!Array.isArray(selected)) {
+    console.error('selected-dbs property must have be an array.');
+    process.exit(1);
+  }
+
+  if(selected.length === 0) return valids;
+
+  if(selected.length > 3) {
+    console.error('selected-dbs has too many values, there are only three valid values: City, Country, ASN.');
+    process.exit(1);
+  }
+
+  for(const value of selected) {
+    const index = valids.indexOf(value);
+    if(index === -1) {
+      console.error(`Invalid value in selected-dbs: ${value}. The only valid values are: City, Country, ASN.`);
+      process.exit(1);
+    }
+  }
+
+  return selected;
+}
+
+module.exports = {
+  getConfig,
+  getLicense,
+  selectedDbs
+}

--- a/utils.js
+++ b/utils.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 const cwdPath = (file) => path.join(process.env['INIT_CWD'] || process.cwd(), file);
 
 const getConfig = () => {
-    const packageJsonFilename = cwdPath('package.json');
+  const packageJsonFilename = cwdPath('package.json');
   const packageJson = require(packageJsonFilename);
   return packageJson['geolite2'] || {};
 };


### PR DESCRIPTION
Here is the pull request allowing user to select which dbs are downloaded using a property on the optional "geolite2" property within package.json.

It does not break the current API, if the property is absent, it will download all dbs.

index.js was adjusted so that only dbs downloaded have path values. Tests were adjusted to only run for downloaded dbs.

Closes #30.