### PR TITLE
Use new Maxmind download URLs and Basic authentication scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ If you don't have access to the environment variables during installation, you c
 
 Beware of security risks of adding keys and secrets to your repository!
 
+**Note:** For backwards compatibility, the account ID is currently optional. When not provided we fall back to using legacy Maxmind download URLs with only the license key. However, this behavior may become unsupported in the future so adding an account ID is recommended. 
+
 ### Selecting databases to download
 
 You can select the dbs you want downloaded by adding a `selected-dbs` property on `geolite2` via `package.json`.

--- a/README.md
+++ b/README.md
@@ -6,14 +6,16 @@ Maxmind's GeoLite2 Free Databases download helper.
 
 ### Access Key
 
-**IMPORTANT** You must setup `MAXMIND_LICENSE_KEY` environment variable be able to download databases. To do so, go to the https://www.maxmind.com/en/geolite2/signup, create a free account and generate new license key.
+**IMPORTANT** You must set up `MAXMIND_ACCOUNT_ID` and `MAXMIND_LICENSE_KEY` environment variables to be able to download databases. To do so, go to the https://www.maxmind.com/en/geolite2/signup, create a free account and generate new license key.
 
-If you don't have access to the environment variables during installation, you can provide license key via `package.json`:
+If you don't have access to the environment variables during installation, you can provide config via `package.json`:
 
 ```jsonc
 {
   ...
   "geolite2": {
+    // specify the account id
+    "account-id": "<your account id>",
     // specify the key
     "license-key": "<your license key>",
     // ... or specify the file where key is located:

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -130,6 +130,7 @@ const main = async () => {
 main()
   .then(() => {
     // success
+    process.exit(0);
   })
   .catch((err) => {
     console.error(err);

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -3,7 +3,7 @@ const https = require('https');
 const zlib = require('zlib');
 const tar = require('tar');
 const path = require('path');
-const { getLicense, getSelectedDbs } = require('../utils');
+const { getAccountId, getLicense, getSelectedDbs } = require('../utils');
 
 let licenseKey;
 try {
@@ -13,16 +13,26 @@ try {
   console.error(e.message);
 }
 
-if (!licenseKey) {
-  console.error(`Error: License key is not configured.\n
+let accountId;
+try {
+  accountId = getAccountId();
+} catch (e) {
+  console.error('geolite2: Error retrieving Maxmind Account ID');
+  console.error(e.message);
+}
+
+if (!licenseKey || !accountId) {
+  console.error(`Error: License Key or Account ID is not configured.\n
   You need to signup for a _free_ Maxmind account to get a license key.
   Go to https://www.maxmind.com/en/geolite2/signup, obtain your key and
   put it in the MAXMIND_LICENSE_KEY environment variable.
 
-  If you don not have access to env vars, put this config in your package.json
+  If you do not have access to env vars, put this config in your package.json
   file (at the root level) like this:
 
   "geolite2": {
+    // specify the account id
+    "account-id": "<your account id>",
     // specify the key
     "license-key": "<your license key>",
     // ... or specify the file where key is located:

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -24,8 +24,9 @@ try {
 if (!licenseKey || !accountId) {
   console.error(`Error: License Key or Account ID is not configured.\n
   You need to signup for a _free_ Maxmind account to get a license key.
-  Go to https://www.maxmind.com/en/geolite2/signup, obtain your key and
-  put it in the MAXMIND_LICENSE_KEY environment variable.
+  Go to https://www.maxmind.com/en/geolite2/signup, obtain your account ID and
+  license key and put them in the MAXMIND_ACCOUNT_ID and MAXMIND_LICENSE_KEY
+  environment variables.
 
   If you do not have access to env vars, put this config in your package.json
   file (at the root level) like this:

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -57,7 +57,10 @@ if (!fs.existsSync(downloadPath)) fs.mkdirSync(downloadPath);
 const request = async (url, options) => {
   const response = await new Promise((resolve, reject) => {
     https
-      .request(url, options, (response) => {
+      .request(url, {
+        auth: `${accountId}:${licenseKey}`,
+        ...options
+      }, (response) => {
         resolve(response);
       })
       .on('error', (err) => reject(err))
@@ -66,7 +69,10 @@ const request = async (url, options) => {
 
   if (response.statusCode >= 300 && response.statusCode < 400 && response.headers.location) {
     // Handle redirect
-    return request(response.headers.location, options);
+    return request(response.headers.location, {
+      ...options,
+      auth: null
+    });
   }
 
   if (response.statusCode !== 200) {

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -33,7 +33,7 @@ if (!licenseKey) {
 }
 
 const link = (edition) =>
-  `https://download.maxmind.com/app/geoip_download?edition_id=${edition}&license_key=${licenseKey}&suffix=tar.gz`;
+  `https://download.maxmind.com/geoip/databases/${edition}/download?suffix=tar.gz`;
 
 const selected = getSelectedDbs();
 const editionIds = ['City', 'Country', 'ASN']

--- a/utils.js
+++ b/utils.js
@@ -19,11 +19,11 @@ const getConfigWithDir = () => {
   }
 
   console.log(
-    "WARN: geolite2 cannot find project's package.json file, using default configuration.\n" +
-    'WARN: geolite2 expects to have maxmind licence key to be present in `MAXMIND_LICENSE_KEY` env variable when package.json is unavailable.'
+    "WARN: geolite2 cannot find configuration in package.json file, using defaults.\n" +
+    "WARN: geolite2 expects to have 'MAXMIND_ACCOUNT_ID' and 'MAXMIND_LICENSE_KEY' to be present in environment variables when package.json is unavailable.",
   );
   console.log(
-    'WARN: geolite2 expected package.json to be preset at a parent of:\n%s',
+    'WARN: geolite2 expected package.json to be present at a parent of:\n%s',
     cwd
   );
 };

--- a/utils.js
+++ b/utils.js
@@ -34,6 +34,16 @@ const getConfig = () => {
   return configWithDir.config;
 };
 
+const getAccountId = () => {
+  const envId = process.env.MAXMIND_ACCOUNT_ID;
+  if (envId) return envId;
+
+  const config = getConfig();
+  if (!config) return;
+
+  return config['account-id'];
+}
+
 const getLicense = () => {
   const envKey = process.env.MAXMIND_LICENSE_KEY;
   if (envKey) return envKey;
@@ -94,6 +104,7 @@ const getSelectedDbs = () => {
 
 module.exports = {
   getConfig,
+  getAccountId,
   getLicense,
   getSelectedDbs,
 };


### PR DESCRIPTION
I recently started to see errors indicating `node-geolite2` was unable to download the database files from Maxmind.

It appears Maxmind has made some changes in the last few months:
https://dev.maxmind.com/geoip/updating-databases?lang=en#directly-downloading-databases

The permalink URLs to download are different, they now redirect to a presigned URL on `r2.cloudflarestorage.com`, and the initial permalink request requires Basic authentication using the Account ID as username and license key as password, instead of passing the license key as a query parameter.

So this PR adds support for:

1. Reading the Maxmind Account ID from env var `MAXMIND_ACCOUNT_ID` or from the config as `account-id`
2. Sending the auth header
3. Following redirects when downloading