### PR TITLE
Fix Node 12.x support

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -61,7 +61,10 @@ const getSelectedDbs = () => {
   const valids = ['City', 'Country', 'ASN'];
 
   const config = getConfig();
-  const selected = config?.['selected-dbs'] ?? valids;
+  const selected =
+    config != null && config['selected-dbs'] != null
+      ? config['selected-dbs']
+      : valids;
 
   if (!Array.isArray(selected)) {
     console.error('selected-dbs property must have be an array.');


### PR DESCRIPTION
In #49 the ES2020 syntax for optional chaining and null coalescing was used.

This is not supported by Node 12.x. I'm not sure if we really still need to target Node 12.x, but to fix the tests we can rewrite to avoid the problem.