### PR TITLE
Use fetch instead of node:https to download files

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "homepage": "https://github.com/runk/node-geolite2#readme",
   "dependencies": {
+    "node-fetch": "^2.7.0",
     "tar": "^5.0.5"
   },
   "devDependencies": {


### PR DESCRIPTION
This replaces use of the node `https` module with `fetch`. See https://github.com/runk/node-geolite2/pull/52#discussion_r1531247776

Note: I opted to use the `node-fetch` implementation rather than Node's built-in `fetch` because I believe this project is still targeting older versions of Node, and built-in `fetch` is not available before 18.x.