### PR TITLE
Allow downloading any MaxMind database

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Beware of security risks of adding keys and secrets to your repository!
 
 You can select the dbs you want downloaded by adding a `selected-dbs` property on `geolite2` via `package.json`.
 
-`selected-dbs` must be an array of strings. To download the GeoLite databases, you can use one or more of the values `City`, `Country`, `ASN`. To download any database, including paid databases, you can use the full edition ID. For example, `GeoIP2-Enterprise`, `GeoIP2-City`, `GeoLite2-City`, etc (downloading paid databases requires an active subscription).
+`selected-dbs` must be an array of edition IDs. For example, `GeoIP2-Enterprise`, `GeoIP2-City`, `GeoLite2-City`, etc (downloading paid databases requires an active subscription).
 
 If `selected-dbs` is unset, or is set but empty, all the free GeoLite dbs will be downloaded.
 
@@ -41,7 +41,7 @@ If `selected-dbs` is unset, or is set but empty, all the free GeoLite dbs will b
 {
   ...
   "geolite2": {
-    "selected-dbs": ["City", "Country", "ASN"]
+    "selected-dbs": ["GeoLite2-City", "GeoLite2-Country", "GeoLite2-ASN"]
   }
   ...
 }
@@ -53,10 +53,9 @@ If `selected-dbs` is unset, or is set but empty, all the free GeoLite dbs will b
 var geolite2 = require('geolite2');
 var maxmind = require('maxmind');
 
-// The database paths are available under geolite2.paths.city,
-// geolite2.paths.country, or geolite2.paths.asn, or by
-// using the full (lower-cased) edition ID, e.g. geolite2.paths['geolite2-asn']
-var lookup = maxmind.openSync(geolite2.paths.city);
+// The database paths are available under geolite2.paths using the full edition
+// ID, e.g. geolite2.paths['GeoLite2-ASN']
+var lookup = maxmind.openSync(geolite2.paths['GeoLite2-City']);
 var city = lookup.get('66.6.44.4');
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # node-geolite2
 
-Maxmind's GeoLite2 Free Databases download helper.
+Maxmind's GeoLite2 Free Databases download helper. Also supports Maxmind's paid GeoIP2 databases.
 
 ## Configuration
 
@@ -27,15 +27,15 @@ If you don't have access to the environment variables during installation, you c
 
 Beware of security risks of adding keys and secrets to your repository!
 
-**Note:** For backwards compatibility, the account ID is currently optional. When not provided we fall back to using legacy Maxmind download URLs with only the license key. However, this behavior may become unsupported in the future so adding an account ID is recommended. 
+**Note:** For backwards compatibility, the account ID is currently optional. When not provided we fall back to using legacy Maxmind download URLs with only the license key. However, this behavior may become unsupported in the future so adding an account ID is recommended.
 
 ### Selecting databases to download
 
 You can select the dbs you want downloaded by adding a `selected-dbs` property on `geolite2` via `package.json`.
 
-`selected-dbs` must be an array of strings, one or more of the values `City`, `Country`, `ASN`.
+`selected-dbs` must be an array of strings. To download the GeoLite databases, you can use one or more of the values `City`, `Country`, `ASN`. To download any database, including paid databases, you can use the full edition ID. For example, `GeoIP2-Enterprise`, `GeoIP2-City`, `GeoLite2-City`, etc (downloading paid databases requires an active subscription).
 
-If `selected-dbs` is unset, or is set but empty, all dbs will be downloaded.
+If `selected-dbs` is unset, or is set but empty, all the free GeoLite dbs will be downloaded.
 
 ```jsonc
 {
@@ -53,7 +53,10 @@ If `selected-dbs` is unset, or is set but empty, all dbs will be downloaded.
 var geolite2 = require('geolite2');
 var maxmind = require('maxmind');
 
-var lookup = maxmind.openSync(geolite2.paths.city); // or geolite2.paths.country or geolite2.paths.asn
+// The database paths are available under geolite2.paths.city,
+// geolite2.paths.country, or geolite2.paths.asn, or by
+// using the full (lower-cased) edition ID, e.g. geolite2.paths['geolite2-asn']
+var lookup = maxmind.openSync(geolite2.paths.city);
 var city = lookup.get('66.6.44.4');
 ```
 

--- a/index.js
+++ b/index.js
@@ -7,17 +7,16 @@ const makePath = (edition) => path.resolve(__dirname, `dbs/${edition}.mmdb`);
 
 const paths = selected.reduce((a, c) => {
   const aliases = {
-    'geolite2-asn': 'asn',
-    'geolite2-city': 'city',
-    'geolite2-country': 'country',
-  }
-  // The keys are lower-case edition IDs
-  key = c.toLowerCase()
-  a[key] = makePath(c);
+    'GeoLite2-ASN': 'asn',
+    'GeoLite2-City': 'city',
+    'GeoLite2-Country': 'country',
+  };
+  // The keys are the database names.
+  a[c] = makePath(c);
   // For backward compatibility, we also populate the 'city', 'asn', and
   // 'country' keys for GeoLite databases.
-  if (key in aliases) {
-    a[aliases[key]] = makePath(c);
+  if (c in aliases) {
+    a[aliases[c]] = makePath(c);
   }
   return a;
 }, {});

--- a/index.js
+++ b/index.js
@@ -3,10 +3,22 @@ const path = require('path');
 const { getSelectedDbs } = require('./utils');
 const selected = getSelectedDbs();
 
-const makePath = (type) => path.resolve(__dirname, `dbs/GeoLite2-${type}.mmdb`);
+const makePath = (edition) => path.resolve(__dirname, `dbs/${edition}.mmdb`);
 
 const paths = selected.reduce((a, c) => {
-  a[c.toLowerCase()] = makePath(c);
+  const aliases = {
+    'geolite2-asn': 'asn',
+    'geolite2-city': 'city',
+    'geolite2-country': 'country',
+  }
+  // The keys are lower-case edition IDs
+  key = c.toLowerCase()
+  a[key] = makePath(c);
+  // For backward compatibility, we also populate the 'city', 'asn', and
+  // 'country' keys for GeoLite databases.
+  if (key in aliases) {
+    a[aliases[key]] = makePath(c);
+  }
   return a;
 }, {});
 

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -50,10 +50,7 @@ const link = (edition) =>
     ? `https://download.maxmind.com/geoip/databases/${edition}/download?suffix=tar.gz`
     : `https://download.maxmind.com/app/geoip_download?edition_id=${edition}&license_key=${licenseKey}&suffix=tar.gz`;
 
-const selected = getSelectedDbs();
-const editionIds = ['City', 'Country', 'ASN']
-  .filter((e) => selected.includes(e))
-  .map((e) => `GeoLite2-${e}`);
+const editionIds = getSelectedDbs();
 
 const downloadPath = path.join(__dirname, '..', 'dbs');
 

--- a/test/index.js
+++ b/test/index.js
@@ -3,6 +3,7 @@ const fs = require('fs');
 const geolite2 = require('../');
 
 describe('geolite2', function () {
+  // Check that the databases downloaded successfully.
   it('should return a valid city db path', function () {
     var stat = fs.statSync(geolite2.paths.city);
     assert(stat.size > 1e6);
@@ -17,6 +18,26 @@ describe('geolite2', function () {
 
   it('should return a valid ASN db path', function () {
     var stat = fs.statSync(geolite2.paths.asn);
+    assert(stat.size > 1e6);
+    assert(stat.ctime);
+  });
+
+  // Also check the new edition-ID-based keys. (These should be the same files
+  // as above.)
+  it('should return a valid city db path with the edition ID', function () {
+    var stat = fs.statSync(geolite2.paths['geolite2-city']);
+    assert(stat.size > 1e6);
+    assert(stat.ctime);
+  });
+
+  it('should return a valid country db path with the edition ID', function () {
+    var stat = fs.statSync(geolite2.paths['geolite2-country']);
+    assert(stat.size > 1e6);
+    assert(stat.ctime);
+  });
+
+  it('should return a valid ASN db path with the edition ID', function () {
+    var stat = fs.statSync(geolite2.paths['geolite2-asn']);
     assert(stat.size > 1e6);
     assert(stat.ctime);
   });

--- a/test/index.js
+++ b/test/index.js
@@ -3,42 +3,21 @@ const fs = require('fs');
 const geolite2 = require('../');
 
 describe('geolite2', function () {
-  // Check that the databases downloaded successfully.
-  it('should return a valid city db path', function () {
-    var stat = fs.statSync(geolite2.paths.city);
-    assert(stat.size > 1e6);
-    assert(stat.ctime);
-  });
+  const keys = [
+    'GeoLite2-ASN',
+    'GeoLite2-City',
+    'GeoLite2-Country',
+    // Legacy aliases:
+    'city',
+    'country',
+    'asn',
+  ];
 
-  it('should return a valid country db path', function () {
-    var stat = fs.statSync(geolite2.paths.country);
-    assert(stat.size > 1e6);
-    assert(stat.ctime);
-  });
-
-  it('should return a valid ASN db path', function () {
-    var stat = fs.statSync(geolite2.paths.asn);
-    assert(stat.size > 1e6);
-    assert(stat.ctime);
-  });
-
-  // Also check the new edition-ID-based keys. (These should be the same files
-  // as above.)
-  it('should return a valid city db path with the edition ID', function () {
-    var stat = fs.statSync(geolite2.paths['geolite2-city']);
-    assert(stat.size > 1e6);
-    assert(stat.ctime);
-  });
-
-  it('should return a valid country db path with the edition ID', function () {
-    var stat = fs.statSync(geolite2.paths['geolite2-country']);
-    assert(stat.size > 1e6);
-    assert(stat.ctime);
-  });
-
-  it('should return a valid ASN db path with the edition ID', function () {
-    var stat = fs.statSync(geolite2.paths['geolite2-asn']);
-    assert(stat.size > 1e6);
-    assert(stat.ctime);
-  });
+  keys.forEach((key) =>
+    it(`should return a database path for ${key}`, () => {
+      var stat = fs.statSync(geolite2.paths[key]);
+      assert(stat.size > 1e6);
+      assert(stat.ctime);
+    }),
+  );
 });

--- a/utils.js
+++ b/utils.js
@@ -113,12 +113,12 @@ const getSelectedDbs = () => {
 
   if (selectedWithPossibleAliases.length === 0) return defaultEditions;
 
-  const selectedEditions = selectedWithPossibleAliases.map(element => {
+  const selectedEditions = selectedWithPossibleAliases.map((element) => {
     index = aliases.indexOf(element);
     if (index > -1) {
       return `GeoLite2-${element}`;
     } else {
-      return element
+      return element;
     }
   });
 
@@ -127,7 +127,7 @@ const getSelectedDbs = () => {
     console.error(
       'Property selected-dbs has too many values, there are only %d valid values: %s',
       validEditions.length,
-      validValuesText
+      validValuesText,
     );
     process.exit(1);
   }
@@ -138,7 +138,7 @@ const getSelectedDbs = () => {
       console.error(
         'Invalid value in selected-dbs: %s The only valid values are: %s',
         value,
-        validValuesText
+        validValuesText,
       );
       process.exit(1);
     }

--- a/utils.js
+++ b/utils.js
@@ -68,33 +68,72 @@ const getLicense = () => {
 };
 
 const getSelectedDbs = () => {
-  const valids = ['City', 'Country', 'ASN'];
+  const aliases = ['ASN', 'City', 'Country'];
+  const defaultEditions = ['GeoLite2-ASN', 'GeoLite2-City', 'GeoLite2-Country'];
+  const validEditions = [
+    'GeoIP-Anonymous-Plus',
+    'GeoIP-Network-Optimization-City',
+    'GeoIP2-Anonymous-IP',
+    'GeoIP2-City',
+    'GeoIP2-City-Africa',
+    'GeoIP2-City-Asia-Pacific',
+    'GeoIP2-City-Europe',
+    'GeoIP2-City-North-America',
+    'GeoIP2-City-Shield',
+    'GeoIP2-City-South-America',
+    'GeoIP2-Connection-Type',
+    'GeoIP2-Country',
+    'GeoIP2-Country-Shield',
+    'GeoIP2-DensityIncome',
+    'GeoIP2-Domain',
+    'GeoIP2-Enterprise',
+    'GeoIP2-Enterprise-Shield',
+    'GeoIP2-IP-Risk',
+    'GeoIP2-ISP',
+    'GeoIP2-Precision-Enterprise',
+    'GeoIP2-Precision-Enterprise-Shield',
+    'GeoIP2-Static-IP-Score',
+    'GeoIP2-User-Connection-Type',
+    'GeoIP2-User-Count',
+    'GeoLite2-ASN',
+    'GeoLite2-City',
+    'GeoLite2-Country',
+  ];
 
   const config = getConfig();
-  const selected =
+  const selectedWithPossibleAliases =
     config != null && config['selected-dbs'] != null
       ? config['selected-dbs']
-      : valids;
+      : defaultEditions;
 
-  if (!Array.isArray(selected)) {
-    console.error('selected-dbs property must have be an array.');
+  if (!Array.isArray(selectedWithPossibleAliases)) {
+    console.error('selected-dbs property must be an array.');
     process.exit(1);
   }
 
-  if (selected.length === 0) return valids;
+  if (selectedWithPossibleAliases.length === 0) return defaultEditions;
 
-  const validValuesText = valids.join(', ');
-  if (selected.length > valids.length) {
+  const selectedEditions = selectedWithPossibleAliases.map(element => {
+    index = aliases.indexOf(element);
+    if (index > -1) {
+      return `GeoLite2-${element}`;
+    } else {
+      return element
+    }
+  });
+
+  const validValuesText = validEditions.join(', ');
+  if (selectedEditions.length > validEditions.length) {
     console.error(
       'Property selected-dbs has too many values, there are only %d valid values: %s',
-      valids.length,
+      validEditions.length,
       validValuesText
     );
     process.exit(1);
   }
 
-  for (const value of selected) {
-    const index = valids.indexOf(value);
+  for (const value of selectedEditions) {
+    const index = validEditions.indexOf(value);
     if (index === -1) {
       console.error(
         'Invalid value in selected-dbs: %s The only valid values are: %s',
@@ -105,7 +144,7 @@ const getSelectedDbs = () => {
     }
   }
 
-  return selected;
+  return selectedEditions;
 };
 
 module.exports = {


### PR DESCRIPTION
This PR allows a user to download any Maxmind database accessible to their Maxmind account, by specifying the full edition ID in the `selected-dbs` array. This allows the downloader to be used for more than the GeoLite databases, so that users can continue using this tool if they upgrade to a subscription database. For example:

```jsonc
{
  ...
  "geolite2": {
    "selected-dbs": ["GeoIP2-Anonymous-IP", "GeoIP2-City-Europe", "GeoIP2-Country-Shield"]
  }
  ...
}
```

The paths to the downloaded databases are available with the lower-cased edition ID as the key on `geolite2.paths`, e.g.

```js
geolite2.paths = {
  'geolite2-asn': '/home/user/node-geolite2/dbs/GeoLite2-ASN.mmdb',
  'geolite2-city': '/home/user/node-geolite2/dbs/GeoLite2-City.mmdb',
  'geolite2-country': '/home/user/node-geolite2/dbs/GeoLite2-Country.mmdb',
}
```

Existing behaviour is maintained — the "City", "Country", and "ASN" keys in `selected-dbs` will still download the GeoLite equivalents. If no `selected-dbs` array is provided, we will still download the three GeoLite databases. We'll still have `city`, `country`, and `asn` keys on `geolite2.paths` when the corresponding GeoLite databases have been downloaded.

This PR fixes https://github.com/runk/node-geolite2/issues/68